### PR TITLE
Add composer.json 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "damyon-atto/hr",
+    "description": "Horizontal Rule for Atto",
+    "type": "moodle-atto",
+    "require": {
+        "composer/installers": "^2.1"
+    },
+    "license": "http://www.gnu.org/copyleft/gpl.html",
+    "authors": [
+        {
+            "name": "Damyon Wiese",
+            "email": "damyon.wiese@gmail.com"
+        }
+    ]
+}


### PR DESCRIPTION
I've added the _type_ `moodle-atto` so that this plugin is [copied to the correct directory when installed using composer](https://github.com/composer/installers/blob/main/src/Composer/Installers/MoodleInstaller.php#L11).

The _name_ after `/` specifies this plugin's directory name after installation.